### PR TITLE
[Bug Fix] Added Auto Creation of Logs Directory 

### DIFF
--- a/src/config/logging.py
+++ b/src/config/logging.py
@@ -1,5 +1,7 @@
 """The file to access the logger to make a relatively decoupled application."""
 
 import logging
+import os
 
+os.makedirs("logs", exist_ok=True)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Bug Fix Pull Request

## Issue Description
On application start, especially for new environments where the logs directory isn't present, the application shows stacktraces due to an invalid URI (`./logs/`)

## Fix Implemented
In the `config.logging.py` file, the `os.makedirs` is used to always create the directory when importing the file. 

This is necessary because if the logs directory were deleted for whatever reason, the application can resume gracefully

## Changes Made
1. `config.logging.py`

## Testing
- Manual testing performed

## Related Issues
#7 

## Checklist
- [x] Code follows the project's style guidelines
- [x] All new and existing tests pass
- [ ] New unit tests and integration tests were added to prevent regression
- [x] Documentation was updated if necessary
- [x] Any necessary database migrations were included
- [x] Tests cover at least 90% of the code if applicable.
